### PR TITLE
Change to "AbortWithStatus"

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -72,7 +72,7 @@ func Middleware(options Options) gin.HandlerFunc {
 				res.Header().Set("Access-Control-Max-Age", strconv.FormatInt(int64(options.MaxAge/time.Second), 10))
 			}
 
-			c.Abort(http.StatusOK)
+			c.AbortWithStatus(http.StatusOK)
 		} else {
 			c.Next()
 		}


### PR DESCRIPTION
The `Abort` method has changed to take no arguments. `AbortWithStatus` should be called instead.
